### PR TITLE
Issue 6 stop scripts from running for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   composer self-update
 
 install:
-  composer install
+  composer install --no-scripts
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false
+
+language: php
+
+php:
+  - '7.2'
+  - '7.3'
+  - nightly
+
+before_install:
+  composer self-update
+
+install:
+  composer install
+
+
+script:
+  phpunit --coverage-text


### PR DESCRIPTION
Added the --no-scripts flag to prevent composer from running scripts on travis, 

> --no-scripts: Skips execution of scripts defined in composer.json.

~ https://getcomposer.org/doc/03-cli.md#install-i