### PR TITLE
Travis Badge added to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Awesome Feed
 
+[![Build Status](https://travis-ci.com/peehaa/feedr.svg?branch=master)](https://travis-ci.com/peehaa/feedr)
+
 Converts any resource into an RSS feed
 
 ## Requirements


### PR DESCRIPTION
The Travis build status badge for master branch is added into the README.md file